### PR TITLE
Remove unused variable from KeyLookup

### DIFF
--- a/KeyLookup.cpp
+++ b/KeyLookup.cpp
@@ -117,8 +117,6 @@ struct ClumpedAnim {
 		for( int start = 0; start < numPrefetchedKeyTimes; ++start ) {
 			if( firstStage[start] > t ) {
 				int l = start*keysPerLump;
-				int h = l + keysPerLump;
-				h = h > numKeys ? numKeys : h;
 				return GetKeyAtTimeLinear( t, l );
 			}
 		}


### PR DESCRIPTION
Since `h` is later not used in GetKeyAtTimeLinear(2) overload, it's safe to remove the variable and avoid potential confusion from the reader.